### PR TITLE
Implement frontend auth with backend API

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -46,7 +46,7 @@ const handleTokenExpired = () => {
   window.location.href = "/login";
 };
 
-initializeApi("", handleTokenExpired);
+initializeApi("http://localhost:3000/api/", handleTokenExpired);
 
 const App = () => (
   <AuthProvider>

--- a/client/lib/auth/ProtectedRoute.tsx
+++ b/client/lib/auth/ProtectedRoute.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "./context";
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
-  requireRole?: "admin" | "worker";
+  requireRole?: "admin" | "worker" | "trabajador";
   fallbackPath?: string;
 }
 
@@ -34,7 +34,11 @@ export function ProtectedRoute({
   }
 
   // Check role-based access if required
-  if (requireRole && user?.role !== requireRole) {
+  if (
+    requireRole &&
+    user?.role !== requireRole &&
+    !(requireRole === "trabajador" && user?.role === "worker")
+  ) {
     // If user doesn't have required role, redirect to dashboard or show unauthorized
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">

--- a/client/lib/auth/api.ts
+++ b/client/lib/auth/api.ts
@@ -219,28 +219,44 @@ export async function apiDelete<T>(
 }
 
 // Token validation function
-export async function validateToken(token: string): Promise<boolean> {
-  try {
-    // For mock purposes, always return true if token exists
-    // In a real app, this would validate with your backend
-    if (token && token.startsWith("mock_jwt_token_")) {
-      return true;
-    }
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
 
-    // Simulate API call to validate token
-    const response = await fetch("/api/auth/validate", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-    });
+export interface LoginSuccess {
+  token: string;
+  user: {
+    id: string;
+    username: string;
+    role: string;
+    firstName: string;
+    lastName: string;
+  };
+}
 
-    return response.ok;
-  } catch (error) {
-    console.error("Token validation failed:", error);
-    return false;
-  }
+export interface VerifyTokenSuccess {
+  valid: boolean;
+  data: {
+    id: string;
+    username: string;
+    name: string;
+    lastName: string;
+    role: string;
+    iat: number;
+    exp: number;
+  };
+}
+
+export async function loginRequest(
+  username: string,
+  password: string,
+): Promise<ApiResponse<LoginSuccess>> {
+  return apiPost<LoginSuccess>("/auth/login", { username, password });
+}
+
+export async function verifyTokenRequest(): Promise<ApiResponse<VerifyTokenSuccess>> {
+  return apiGet<VerifyTokenSuccess>("/auth/verify");
 }
 
 // Refresh token function

--- a/client/lib/auth/index.ts
+++ b/client/lib/auth/index.ts
@@ -24,7 +24,8 @@ export {
   apiPut,
   apiPatch,
   apiDelete,
-  validateToken,
+  loginRequest,
+  verifyTokenRequest,
   refreshToken,
 } from "./api";
 export type { ApiResponse } from "./api";

--- a/client/pages/Login.tsx
+++ b/client/pages/Login.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/auth";
 
 interface LoginFormData {
-  email: string;
+  username: string;
   password: string;
 }
 
@@ -16,7 +16,7 @@ export function Login() {
   const { isAuthenticated, login } = useAuth();
   const location = useLocation();
   const [formData, setFormData] = useState<LoginFormData>({
-    email: "",
+    username: "",
     password: "",
   });
   const [showPassword, setShowPassword] = useState(false);
@@ -37,13 +37,13 @@ export function Login() {
     setError("");
 
     try {
-      await login(formData.email, formData.password);
+      await login(formData.username, formData.password);
       // Navigation will be handled automatically by the redirect above
     } catch (err) {
       setError(
         err instanceof Error
           ? err.message
-          : "Credenciales inválidas. Por favor, verifica tu email y contraseña.",
+          : "Credenciales inválidas. Por favor, verifica tu usuario y contraseña.",
       );
     } finally {
       setIsLoading(false);
@@ -133,18 +133,18 @@ export function Login() {
             <form onSubmit={handleSubmit} className="space-y-6">
               <div className="space-y-2">
                 <Label
-                  htmlFor="email"
+                  htmlFor="username"
                   className="text-sm font-medium text-foreground"
                 >
-                  Correo Electrónico
+                  Usuario
                 </Label>
                 <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  value={formData.email}
+                  id="username"
+                  name="username"
+                  type="text"
+                  value={formData.username}
                   onChange={handleInputChange}
-                  placeholder="tu@email.com"
+                  placeholder="usuario"
                   required
                   className={cn(
                     "input-modern",
@@ -224,8 +224,8 @@ export function Login() {
                   size="sm"
                   onClick={() => {
                     setFormData({
-                      email: "admin@podocare.com",
-                      password: "admin123",
+                      username: "admin@demo.com",
+                      password: "demo123",
                     });
                     setError("");
                   }}
@@ -242,8 +242,8 @@ export function Login() {
                   size="sm"
                   onClick={() => {
                     setFormData({
-                      email: "worker@podocare.com",
-                      password: "worker123",
+                      username: "worker@demo.com",
+                      password: "demo123",
                     });
                     setError("");
                   }}


### PR DESCRIPTION
## Summary
- integrate login and token verification with backend API
- add role helpers and session verification in `AuthProvider`
- update protected route logic for `trabajador` role
- default API base URL to `http://localhost:3000/api/`
- adjust login page to use username and demo credentials

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68770a35adf88329be7a60c38cce61ce