### PR TITLE
Implement patient edit page

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -26,6 +26,7 @@ import ScheduleAppointment from "./pages/ScheduleAppointment";
 import Abonos from "./pages/Abonos";
 import PatientDetail from "./pages/PatientDetail";
 import CreatePatient from "./pages/CreatePatient";
+import EditPatient from "./pages/EditPatient";
 import ProductDetail from "./pages/ProductDetail";
 import WorkerDetail from "./pages/WorkerDetail";
 import Categories from "./pages/Categories";
@@ -93,6 +94,14 @@ const App = () => (
                 element={
                   <ProtectedRoute>
                     <CreatePatient />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/patients/:id/edit"
+                element={
+                  <ProtectedRoute>
+                    <EditPatient />
                   </ProtectedRoute>
                 }
               />

--- a/client/lib/api/patient.ts
+++ b/client/lib/api/patient.ts
@@ -5,6 +5,7 @@ import type {
   PaginatedResponse,
   PaginatedSearchParams,
   Patient,
+  UpdatePatientDto,
   ApiResponse,
 } from "@shared/api";
 
@@ -48,7 +49,15 @@ export class PatientRepository {
     return resp.data.data;
   }
 
-  async update(id: string, data: Partial<Patient>): Promise<Patient> {
+  async getById(id: string): Promise<Patient> {
+    const resp = await apiGet<ApiResponse<Patient>>(`/patient/${id}`);
+    if (resp.error || !resp.data) {
+      throw new Error(resp.error || "Failed to fetch patient");
+    }
+    return resp.data.data;
+  }
+
+  async update(id: string, data: UpdatePatientDto): Promise<Patient> {
     const resp = await apiPut<ApiResponse<Patient>>(`/patient/${id}`, data);
     if (resp.error || !resp.data) {
       throw new Error(resp.error || "Failed to update patient");

--- a/client/pages/EditPatient.tsx
+++ b/client/pages/EditPatient.tsx
@@ -1,0 +1,346 @@
+import React, { useState, useEffect, useMemo } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, Save, User } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import Layout from "@/components/Layout";
+import { Patient, UpdatePatientDto } from "@shared/api";
+import { PatientRepository } from "@/lib/api/patient";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+} from "@/components/ui/alert-dialog";
+
+export default function EditPatient() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const repository = useMemo(() => new PatientRepository(), []);
+
+  const [formData, setFormData] = useState<Patient | UpdatePatientDto>({
+    documentType: "dni",
+    documentNumber: "",
+    firstName: "",
+    paternalSurname: "",
+    maternalSurname: "",
+    gender: "m",
+    phone: "",
+    birthDate: "",
+    email: "",
+    allergy: "",
+    diabetic: false,
+    hypertensive: false,
+    otherConditions: "",
+    balance: 0,
+  });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [backendError, setBackendError] = useState<string>("");
+
+  const [successDialogOpen, setSuccessDialogOpen] = useState(false);
+  const [errorDialogOpen, setErrorDialogOpen] = useState(false);
+
+  useEffect(() => {
+    const loadPatient = async () => {
+      if (!id) return;
+      try {
+        const patient = await repository.getById(id);
+        setFormData(patient);
+      } catch (err) {
+        console.error("Error loading patient:", err);
+        navigate("/patients");
+      }
+    };
+    loadPatient();
+  }, [id, navigate, repository]);
+
+  const validate = () => {
+    const errs: Record<string, string> = {};
+    if (!formData.documentType) errs.documentType = "Campo requerido";
+    if (!formData.firstName?.trim()) errs.firstName = "Campo requerido";
+    if (!formData.paternalSurname?.trim()) errs.paternalSurname = "Campo requerido";
+    if (!formData.maternalSurname?.trim()) errs.maternalSurname = "Campo requerido";
+    if (!formData.documentNumber?.trim()) errs.documentNumber = "Campo requerido";
+    if (!formData.phone?.trim()) errs.phone = "Campo requerido";
+    if (!formData.birthDate) errs.birthDate = "Campo requerido";
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!id) return;
+    setBackendError("");
+    if (!validate()) return;
+    try {
+      await repository.update(id, formData as UpdatePatientDto);
+      setSuccessDialogOpen(true);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Error desconocido";
+      setBackendError(msg);
+      setErrorDialogOpen(true);
+    }
+  };
+
+  return (
+    <Layout title="Editar Paciente" subtitle="Actualizar información del paciente">
+      <div className="p-6 space-y-6">
+        <Button
+          variant="outline"
+          onClick={() => navigate(`/patients/${id}`)}
+          className="flex items-center gap-2"
+        >
+          <ArrowLeft className="w-4 h-4" /> Volver
+        </Button>
+
+        <Card className="card-modern">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <User className="w-6 h-6 text-primary" /> Datos del Paciente
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="documentType">Tipo Documento *</Label>
+                  <Select
+                    value={formData.documentType}
+                    onValueChange={(value: 'dni' | 'passport') =>
+                      setFormData({ ...formData, documentType: value })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="dni">DNI</SelectItem>
+                      <SelectItem value="passport">Pasaporte</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {errors.documentType && (
+                    <p className="text-sm text-destructive">{errors.documentType}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="documentNumber">Nº Documento *</Label>
+                  <Input
+                    id="documentNumber"
+                    value={formData.documentNumber}
+                    onChange={(e) =>
+                      setFormData({ ...formData, documentNumber: e.target.value })
+                    }
+                  />
+                  {errors.documentNumber && (
+                    <p className="text-sm text-destructive">{errors.documentNumber}</p>
+                  )}
+                </div>
+                <div className="space-y-2 col-span-2">
+                  <Label htmlFor="firstName">Nombres *</Label>
+                  <Input
+                    id="firstName"
+                    value={formData.firstName}
+                    onChange={(e) =>
+                      setFormData({ ...formData, firstName: e.target.value })
+                    }
+                  />
+                  {errors.firstName && (
+                    <p className="text-sm text-destructive">{errors.firstName}</p>
+                  )}
+                </div>
+                <div className="space-y-2 w-full">
+                  <Label htmlFor="paternalSurname">Apellido Paterno *</Label>
+                  <Input
+                    id="paternalSurname"
+                    value={formData.paternalSurname}
+                    onChange={(e) =>
+                      setFormData({ ...formData, paternalSurname: e.target.value })
+                    }
+                  />
+                  {errors.paternalSurname && (
+                    <p className="text-sm text-destructive">{errors.paternalSurname}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="maternalSurname">Apellido Materno *</Label>
+                  <Input
+                    id="maternalSurname"
+                    value={formData.maternalSurname}
+                    onChange={(e) =>
+                      setFormData({ ...formData, maternalSurname: e.target.value })
+                    }
+                  />
+                  {errors.maternalSurname && (
+                    <p className="text-sm text-destructive">{errors.maternalSurname}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="phone">Teléfono *</Label>
+                  <Input
+                    id="phone"
+                    value={formData.phone}
+                    onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
+                  />
+                  {errors.phone && (
+                    <p className="text-sm text-destructive">{errors.phone}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="email">Email</Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    value={formData.email || ""}
+                    onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="gender">Sexo *</Label>
+                  <Select
+                    value={formData.gender}
+                    onValueChange={(value: 'm' | 'f') =>
+                      setFormData({ ...formData, gender: value })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="f">Femenino</SelectItem>
+                      <SelectItem value="m">Masculino</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {errors.gender && (
+                    <p className="text-sm text-destructive">{errors.gender}</p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="birthDate">Fecha de Nacimiento *</Label>
+                  <Input
+                    id="birthDate"
+                    type="date"
+                    value={formData.birthDate}
+                    onChange={(e) => setFormData({ ...formData, birthDate: e.target.value })}
+                  />
+                  {errors.birthDate && (
+                    <p className="text-sm text-destructive">{errors.birthDate}</p>
+                  )}
+                </div>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="diabetic">Diabético</Label>
+                  <Select
+                    value={formData.diabetic ? 'yes' : 'no'}
+                    onValueChange={(val) =>
+                      setFormData({ ...formData, diabetic: val === 'yes' })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="yes">Sí</SelectItem>
+                      <SelectItem value="no">No</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="hypertensive">Hipertenso</Label>
+                  <Select
+                    value={formData.hypertensive ? 'yes' : 'no'}
+                    onValueChange={(val) =>
+                      setFormData({ ...formData, hypertensive: val === 'yes' })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="yes">Sí</SelectItem>
+                      <SelectItem value="no">No</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2 col-span-2">
+                  <Label htmlFor="allergy">Alergias</Label>
+                  <Input
+                    id="allergy"
+                    value={formData.allergy || ""}
+                    onChange={(e) => setFormData({ ...formData, allergy: e.target.value })}
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="otherConditions">Otras Condiciones</Label>
+                <Textarea
+                  id="otherConditions"
+                  value={formData.otherConditions || ""}
+                  onChange={(e) =>
+                    setFormData({ ...formData, otherConditions: e.target.value })
+                  }
+                  rows={3}
+                />
+              </div>
+              <div className="flex justify-end gap-3">
+                <Button type="button" variant="outline" onClick={() => navigate(`/patients/${id}`)}>
+                  Cancelar
+                </Button>
+                <Button type="submit" className="btn-primary">
+                  <Save className="w-4 h-4 mr-2" /> Guardar Cambios
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+
+      <AlertDialog open={successDialogOpen} onOpenChange={setSuccessDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Paciente actualizado</AlertDialogTitle>
+            <AlertDialogDescription>
+              Los datos del paciente se actualizaron correctamente.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button
+              onClick={() => {
+                setSuccessDialogOpen(false);
+                navigate(`/patients/${id}`);
+              }}
+            >
+              Aceptar
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={errorDialogOpen} onOpenChange={setErrorDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Error</AlertDialogTitle>
+            <AlertDialogDescription className="text-destructive">
+              {backendError || "Ocurrió un error al actualizar el paciente."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button onClick={() => setErrorDialogOpen(false)}>Cerrar</Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Layout>
+  );
+}

--- a/client/pages/PatientDetail.tsx
+++ b/client/pages/PatientDetail.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
+  Edit,
   User,
   Phone,
   Calendar,
@@ -342,6 +343,14 @@ export function PatientDetail() {
           >
             <ArrowLeft className="w-4 h-4" />
             Volver a Pacientes
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => navigate(`/patients/${patient.id}/edit`)}
+            className="flex items-center gap-2"
+          >
+            <Edit className="w-4 h-4" />
+            Editar
           </Button>
         </div>
 

--- a/client/pages/Patients.tsx
+++ b/client/pages/Patients.tsx
@@ -35,6 +35,14 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+} from "@/components/ui/alert-dialog";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -73,6 +81,8 @@ export function Patients() {
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isViewDialogOpen, setIsViewDialogOpen] = useState(false);
+  const [backendError, setBackendError] = useState<string>("");
+  const [errorDialogOpen, setErrorDialogOpen] = useState(false);
 
   // Repository-based pagination
   const pagination = useRepositoryPagination<Patient>({
@@ -127,10 +137,11 @@ export function Patients() {
       setIsEditDialogOpen(false);
       setSelectedPatient(null);
       resetForm();
-      // Refresh the data
       await loadPatients();
     } catch (error) {
-      console.error("Error updating patient:", error);
+      const msg = error instanceof Error ? error.message : "Error desconocido";
+      setBackendError(msg);
+      setErrorDialogOpen(true);
     }
   };
 
@@ -714,6 +725,20 @@ export function Patients() {
             </div>
           </DialogContent>
         </Dialog>
+
+        <AlertDialog open={errorDialogOpen} onOpenChange={setErrorDialogOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Error</AlertDialogTitle>
+              <AlertDialogDescription className="text-destructive">
+                {backendError || "Ocurrió un error al actualizar el paciente."}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <Button onClick={() => setErrorDialogOpen(false)}>Cerrar</Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         {/* View Patient Dialog */}
         <Dialog open={isViewDialogOpen} onOpenChange={setIsViewDialogOpen}>

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -49,6 +49,22 @@ export interface CreatePatientRequest {
   clinicalNotes?: string;
 }
 
+export interface UpdatePatientDto {
+  documentType?: 'dni' | 'passport';
+  documentNumber?: string;
+  firstName?: string;
+  paternalSurname?: string;
+  maternalSurname?: string;
+  gender?: 'm' | 'f';
+  email?: string;
+  phone?: string;
+  birthDate?: string;
+  allergy?: string;
+  diabetic?: boolean;
+  hypertensive?: boolean;
+  otherConditions?: string;
+}
+
 // Worker Types
 export interface Worker {
   id: string;


### PR DESCRIPTION
## Summary
- add `UpdatePatientDto` shared type for editing
- support patient `getById` and typed `update`
- create edit patient page and route
- allow navigating to edit from patient detail
- show backend errors when editing

## Testing
- `npm test`
- `npm run typecheck` *(fails: client/pages/Workers.tsx issues)*

------
https://chatgpt.com/codex/tasks/task_e_6878623411ac8329ac47904c1740c166