### PR TITLE
Implement patient detail view API

### DIFF
--- a/client/lib/api/patient.ts
+++ b/client/lib/api/patient.ts
@@ -7,6 +7,7 @@ import type {
   Patient,
   UpdatePatientDto,
   ApiResponse,
+  PatientDetailStatistics,
 } from "@shared/api";
 
 export class PatientRepository {
@@ -26,12 +27,7 @@ export class PatientRepository {
     if (resp.error || !resp.data) {
       throw new Error(resp.error || "Failed to fetch patients");
     }
-    const {
-      data: items,
-      total,
-      page,
-      limit,
-    } = resp.data.data;
+    const { data: items, total, page, limit } = resp.data.data;
     return {
       items,
       total,
@@ -64,5 +60,14 @@ export class PatientRepository {
     }
     return resp.data.data;
   }
-}
 
+  async getDetailStatistics(id: string): Promise<PatientDetailStatistics> {
+    const resp = await apiGet<ApiResponse<PatientDetailStatistics>>(
+      `/patient/${id}/detail-statistics`,
+    );
+    if (resp.error || !resp.data) {
+      throw new Error(resp.error || "Failed to fetch patient detail");
+    }
+    return resp.data.data;
+  }
+}

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -21,12 +21,12 @@ export interface LoginResponse {
 // Patient Types
 export interface Patient {
   id?: any;
-  documentType: 'dni' | 'passport';
+  documentType: "dni" | "passport";
   documentNumber: string;
   firstName: string;
   paternalSurname: string;
   maternalSurname: string;
-  gender: 'm' | 'f';
+  gender: "m" | "f";
   email?: string;
   phone?: string;
   birthDate: string;
@@ -50,12 +50,12 @@ export interface CreatePatientRequest {
 }
 
 export interface UpdatePatientDto {
-  documentType?: 'dni' | 'passport';
+  documentType?: "dni" | "passport";
   documentNumber?: string;
   firstName?: string;
   paternalSurname?: string;
   maternalSurname?: string;
-  gender?: 'm' | 'f';
+  gender?: "m" | "f";
   email?: string;
   phone?: string;
   birthDate?: string;
@@ -382,7 +382,7 @@ export interface SearchParams {
   [key: string]: any;
 }
 
-export interface PaginatedSearchParams extends PaginationParams, SearchParams { }
+export interface PaginatedSearchParams extends PaginationParams, SearchParams {}
 
 // Patient listing data returned by the real API
 
@@ -415,4 +415,13 @@ export interface PatientListResponse {
     page: number;
     limit: number;
   };
+}
+
+export interface PatientDetailStatistics {
+  patient: Patient;
+  appointments: Appointment[];
+  sales: Sale[];
+  abonos: Abono[];
+  abonoUsage: AbonoUsage[];
+  patientPackages: PatientPackage[];
 }


### PR DESCRIPTION
## Summary
- define `PatientDetailStatistics` interface
- add `getDetailStatistics` to PatientRepository
- load patient detail data from API instead of mock data

## Testing
- `npm test`
- `npm run typecheck` *(fails: Property 'workerType' does not exist in Workers.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68787a8974048329ad0db247c115fad5