### PR TITLE
Implement categories api integration

### DIFF
--- a/client/pages/Categories.tsx
+++ b/client/pages/Categories.tsx
@@ -1,20 +1,16 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  Tag,
-  Plus,
-  Search,
-  Edit,
-  Trash2,
-  Save,
-  X,
-  ArrowLeft,
-  Package,
-} from "lucide-react";
+import { Tag, Plus, Search, Edit, Trash2, Save, ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Dialog,
   DialogContent,
@@ -32,104 +28,130 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
-import { ProductCategory } from "@shared/api";
-import { getMockProductCategories, getAllMockProducts } from "@/lib/mockData";
+import {
+  ProductCategory,
+  PaginatedResponse,
+  PaginatedSearchParams,
+} from "@shared/api";
+import {
+  apiGet,
+  apiPost,
+  apiPut,
+  apiDelete,
+  type ApiResponse,
+} from "@/lib/auth";
 import Layout from "@/components/Layout";
+import { Pagination } from "@/components/ui/pagination";
+import { useRepositoryPagination } from "@/hooks/use-repository-pagination";
 
 interface CreateCategoryRequest {
   name: string;
-  description?: string;
+  status?: "active" | "inactive";
 }
 
 export function Categories() {
   const navigate = useNavigate();
-  const [categories, setCategories] = useState<ProductCategory[]>([]);
-  const [products, setProducts] = useState([]);
-  const [filteredCategories, setFilteredCategories] = useState<
-    ProductCategory[]
-  >([]);
-  const [searchTerm, setSearchTerm] = useState("");
+  const pagination = useRepositoryPagination<ProductCategory>({
+    initialPageSize: 10,
+  });
+
+  const [allCategories, setAllCategories] = useState<ProductCategory[]>([]);
   const [selectedCategory, setSelectedCategory] =
     useState<ProductCategory | null>(null);
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  // Form state for new/edit category
   const [categoryFormData, setCategoryFormData] =
     useState<CreateCategoryRequest>({
       name: "",
-      description: "",
+      status: "active",
     });
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    loadData();
+    loadAllCategories();
   }, []);
 
   useEffect(() => {
-    // Filter categories based on search term
-    const filtered = categories.filter(
-      (category) =>
-        category.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        (category.description &&
-          category.description
-            .toLowerCase()
-            .includes(searchTerm.toLowerCase())),
-    );
-    setFilteredCategories(filtered);
-  }, [categories, searchTerm]);
+    loadCategories();
+  }, [pagination.currentPage, pagination.pageSize, pagination.searchTerm]);
 
-  const loadData = async () => {
-    setIsLoading(true);
+  const buildQuery = (params: PaginatedSearchParams) => {
+    const sp = new URLSearchParams();
+    if (params.page) sp.append("page", String(params.page));
+    if (params.limit) sp.append("limit", String(params.limit));
+    if (params.search) sp.append("search", params.search);
+    return sp.toString();
+  };
+
+  const loadAllCategories = async () => {
     try {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      const mockCategories = getMockProductCategories();
-      const mockProducts = getAllMockProducts();
-      setCategories(mockCategories);
-      setProducts(mockProducts);
+      const resp = await apiGet<
+        ApiResponse<{
+          data: ProductCategory[];
+          total: number;
+          page: number;
+          limit: number;
+        }>
+      >("/product-category?page=1&limit=1000");
+      if (!resp.error && resp.data) {
+        setAllCategories(resp.data.data.data);
+      }
     } catch (error) {
       console.error("Error loading categories:", error);
-    } finally {
-      setIsLoading(false);
     }
   };
 
-  const getProductCount = (categoryId: string) => {
-    return products.filter((product) => product.categoryId === categoryId)
-      .length;
+  const loadCategories = async () => {
+    await pagination.loadData(async (params: PaginatedSearchParams) => {
+      const query = buildQuery(params);
+      const resp = await apiGet<
+        ApiResponse<{
+          data: ProductCategory[];
+          total: number;
+          page: number;
+          limit: number;
+        }>
+      >(`/product-category?${query}`);
+      if (resp.error || !resp.data) {
+        throw new Error(resp.error || "Failed to fetch categories");
+      }
+      const { data, total, page, limit } = resp.data.data;
+      return {
+        items: data,
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      } as PaginatedResponse<ProductCategory>;
+    });
   };
 
   const validateForm = () => {
     const errors: Record<string, string> = {};
-
     if (!categoryFormData.name.trim()) {
       errors.name = "El nombre es requerido";
     }
-
     setFormErrors(errors);
     return Object.keys(errors).length === 0;
   };
 
   const handleAddCategory = async () => {
     if (!validateForm()) return;
-
     setIsLoading(true);
     try {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      const newCategory: ProductCategory = {
-        id: `category_${Date.now()}`,
-        name: categoryFormData.name,
-        description: categoryFormData.description,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      };
-
-      setCategories([...categories, newCategory]);
+      const resp = await apiPost<ApiResponse<ProductCategory>>(
+        "/product-category",
+        categoryFormData,
+      );
+      if (resp.error || !resp.data) {
+        throw new Error(resp.error || "Failed to create category");
+      }
       setIsAddDialogOpen(false);
-      setCategoryFormData({ name: "", description: "" });
-      setFormErrors({});
+      setCategoryFormData({ name: "", status: "active" });
+      await loadAllCategories();
+      await loadCategories();
     } catch (error) {
       console.error("Error adding category:", error);
     } finally {
@@ -138,28 +160,21 @@ export function Categories() {
   };
 
   const handleEditCategory = async () => {
-    if (!validateForm() || !selectedCategory) return;
-
+    if (!selectedCategory || !validateForm()) return;
     setIsLoading(true);
     try {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      const updatedCategory: ProductCategory = {
-        ...selectedCategory,
-        name: categoryFormData.name,
-        description: categoryFormData.description,
-        updatedAt: new Date().toISOString(),
-      };
-
-      setCategories(
-        categories.map((c) =>
-          c.id === selectedCategory.id ? updatedCategory : c,
-        ),
+      const resp = await apiPut<ApiResponse<ProductCategory>>(
+        `/product-category/${selectedCategory.id}`,
+        categoryFormData,
       );
+      if (resp.error || !resp.data) {
+        throw new Error(resp.error || "Failed to update category");
+      }
       setIsEditDialogOpen(false);
       setSelectedCategory(null);
-      setCategoryFormData({ name: "", description: "" });
-      setFormErrors({});
+      setCategoryFormData({ name: "", status: "active" });
+      await loadAllCategories();
+      await loadCategories();
     } catch (error) {
       console.error("Error editing category:", error);
     } finally {
@@ -168,27 +183,23 @@ export function Categories() {
   };
 
   const handleDeleteCategory = async (category: ProductCategory) => {
-    const productCount = getProductCount(category.id);
-
-    if (productCount > 0) {
-      alert(
-        `No se puede eliminar la categoría "${category.name}" porque tiene ${productCount} producto(s) asociado(s).`,
-      );
-      return;
-    }
-
     if (
       !confirm(
         `¿Estás seguro de que quieres eliminar la categoría "${category.name}"?`,
       )
-    ) {
+    )
       return;
-    }
-
     setIsLoading(true);
     try {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      setCategories(categories.filter((c) => c.id !== category.id));
+      const resp = await apiDelete<ApiResponse<any>>(
+        `/product-category/${category.id}`,
+      );
+      if (resp.error) {
+        alert(resp.error);
+      } else {
+        await loadAllCategories();
+        await loadCategories();
+      }
     } catch (error) {
       console.error("Error deleting category:", error);
     } finally {
@@ -198,38 +209,20 @@ export function Categories() {
 
   const openEditDialog = (category: ProductCategory) => {
     setSelectedCategory(category);
-    setCategoryFormData({
-      name: category.name,
-      description: category.description || "",
-    });
+    setCategoryFormData({ name: category.name, status: category.status });
     setFormErrors({});
     setIsEditDialogOpen(true);
   };
 
   const openAddDialog = () => {
-    setCategoryFormData({ name: "", description: "" });
+    setCategoryFormData({ name: "", status: "active" });
     setFormErrors({});
     setIsAddDialogOpen(true);
   };
 
-  if (isLoading && categories.length === 0) {
-    return (
-      <Layout title="Categorías" subtitle="Gestión de categorías de productos">
-        <div className="p-6">
-          <div className="space-y-4">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="loading-shimmer h-16 rounded"></div>
-            ))}
-          </div>
-        </div>
-      </Layout>
-    );
-  }
-
   return (
     <Layout title="Categorías" subtitle="Gestión de categorías de productos">
       <div className="p-6 space-y-6">
-        {/* Header */}
         <div className="flex items-center justify-between">
           <Button
             variant="outline"
@@ -245,7 +238,6 @@ export function Categories() {
           </Button>
         </div>
 
-        {/* Search and Filters */}
         <Card className="card-modern">
           <CardContent className="p-4">
             <div className="flex flex-col sm:flex-row gap-4">
@@ -253,8 +245,8 @@ export function Categories() {
                 <Search className="w-4 h-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" />
                 <Input
                   placeholder="Buscar categorías..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
+                  value={pagination.searchTerm}
+                  onChange={(e) => pagination.setSearchTerm(e.target.value)}
                   className="pl-10"
                 />
               </div>
@@ -262,8 +254,7 @@ export function Categories() {
           </CardContent>
         </Card>
 
-        {/* Statistics */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <Card className="card-modern">
             <CardContent className="p-6">
               <div className="flex items-center gap-3">
@@ -274,28 +265,11 @@ export function Categories() {
                   <p className="text-sm text-muted-foreground">
                     Total Categorías
                   </p>
-                  <p className="text-2xl font-bold">{categories.length}</p>
+                  <p className="text-2xl font-bold">{allCategories.length}</p>
                 </div>
               </div>
             </CardContent>
           </Card>
-
-          <Card className="card-modern">
-            <CardContent className="p-6">
-              <div className="flex items-center gap-3">
-                <div className="p-3 bg-secondary/10 rounded-lg">
-                  <Package className="w-6 h-6 text-secondary" />
-                </div>
-                <div>
-                  <p className="text-sm text-muted-foreground">
-                    Total Productos
-                  </p>
-                  <p className="text-2xl font-bold">{products.length}</p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
           <Card className="card-modern">
             <CardContent className="p-6">
               <div className="flex items-center gap-3">
@@ -307,7 +281,7 @@ export function Categories() {
                     Categorías Activas
                   </p>
                   <p className="text-2xl font-bold">
-                    {filteredCategories.length}
+                    {allCategories.filter((c) => c.status === "active").length}
                   </p>
                 </div>
               </div>
@@ -315,27 +289,27 @@ export function Categories() {
           </Card>
         </div>
 
-        {/* Categories Table */}
         <Card className="card-modern">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Tag className="w-5 h-5" />
-              Categorías ({filteredCategories.length})
+              Categorías ({pagination.totalItems})
             </CardTitle>
           </CardHeader>
           <CardContent>
-            {filteredCategories.length === 0 ? (
+            {pagination.isLoading ? (
+              <div className="space-y-4">
+                {Array.from({ length: pagination.pageSize }).map((_, i) => (
+                  <div key={i} className="loading-shimmer h-8 rounded" />
+                ))}
+              </div>
+            ) : pagination.data.length === 0 ? (
               <div className="text-center py-12 text-muted-foreground">
                 <Tag className="w-16 h-16 mx-auto mb-4 opacity-50" />
                 <p className="text-lg font-medium">
                   No se encontraron categorías
                 </p>
-                <p className="text-sm">
-                  {searchTerm
-                    ? "Intenta ajustar tu búsqueda"
-                    : "Crea tu primera categoría para organizar los productos"}
-                </p>
-                {!searchTerm && (
+                {!pagination.searchTerm && (
                   <Button onClick={openAddDialog} className="mt-4">
                     <Plus className="w-4 h-4 mr-2" />
                     Nueva Categoría
@@ -348,64 +322,67 @@ export function Categories() {
                   <TableHeader>
                     <TableRow>
                       <TableHead>Nombre</TableHead>
-                      <TableHead>Descripción</TableHead>
-                      <TableHead>Productos</TableHead>
-                      <TableHead>Fecha Creación</TableHead>
+                      <TableHead>Slug</TableHead>
+                      <TableHead>Estado</TableHead>
                       <TableHead className="text-right">Acciones</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {filteredCategories.map((category) => {
-                      const productCount = getProductCount(category.id);
-                      return (
-                        <TableRow
-                          key={category.id}
-                          className="hover:bg-muted/50"
-                        >
-                          <TableCell>
-                            <div className="font-medium">{category.name}</div>
-                          </TableCell>
-                          <TableCell>
-                            <div className="text-sm text-muted-foreground max-w-md truncate">
-                              {category.description || "Sin descripción"}
-                            </div>
-                          </TableCell>
-                          <TableCell>
-                            <Badge variant="outline" className="text-xs">
-                              {productCount} productos
-                            </Badge>
-                          </TableCell>
-                          <TableCell>
-                            <div className="text-sm text-muted-foreground">
-                              {new Date(
-                                category.createdAt,
-                              ).toLocaleDateString()}
-                            </div>
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <div className="flex items-center justify-end gap-2">
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => openEditDialog(category)}
-                              >
-                                <Edit className="w-4 h-4" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleDeleteCategory(category)}
-                                className="text-destructive hover:text-destructive"
-                              >
-                                <Trash2 className="w-4 h-4" />
-                              </Button>
-                            </div>
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
+                    {pagination.data.map((category) => (
+                      <TableRow key={category.id} className="hover:bg-muted/50">
+                        <TableCell className="font-medium">
+                          {category.name}
+                        </TableCell>
+                        <TableCell>
+                          <code className="text-sm bg-muted px-2 py-1 rounded">
+                            {category.slug}
+                          </code>
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              category.status === "active"
+                                ? "default"
+                                : "secondary"
+                            }
+                          >
+                            {category.status === "active"
+                              ? "Activa"
+                              : "Inactiva"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex items-center justify-end gap-2">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => openEditDialog(category)}
+                            >
+                              <Edit className="w-4 h-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleDeleteCategory(category)}
+                              className="text-destructive hover:text-destructive"
+                            >
+                              <Trash2 className="w-4 h-4" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
                   </TableBody>
                 </Table>
+
+                <Pagination
+                  currentPage={pagination.currentPage}
+                  totalPages={pagination.totalPages}
+                  totalItems={pagination.totalItems}
+                  pageSize={pagination.pageSize}
+                  onPageChange={pagination.goToPage}
+                  onPageSizeChange={pagination.setPageSize}
+                />
               </div>
             )}
           </CardContent>
@@ -414,14 +391,13 @@ export function Categories() {
 
       {/* Add Category Dialog */}
       <Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
-        <DialogContent className="sm:max-w-[500px]">
+        <DialogContent className="sm:max-w-[400px]">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Plus className="w-5 h-5 text-primary" />
               Nueva Categoría
             </DialogTitle>
           </DialogHeader>
-
           <div className="space-y-4 py-4">
             <div className="space-y-2">
               <Label htmlFor="add-name">Nombre *</Label>
@@ -441,24 +417,27 @@ export function Categories() {
                 <p className="text-sm text-destructive">{formErrors.name}</p>
               )}
             </div>
-
             <div className="space-y-2">
-              <Label htmlFor="add-description">Descripción</Label>
-              <Textarea
-                id="add-description"
-                value={categoryFormData.description}
-                onChange={(e) =>
+              <Label>Estado</Label>
+              <Select
+                value={categoryFormData.status}
+                onValueChange={(value) =>
                   setCategoryFormData({
                     ...categoryFormData,
-                    description: e.target.value,
+                    status: value as "active" | "inactive",
                   })
                 }
-                placeholder="Descripción de la categoría (opcional)"
-                rows={3}
-              />
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="active">Activa</SelectItem>
+                  <SelectItem value="inactive">Inactiva</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </div>
-
           <div className="flex justify-end gap-3">
             <Button
               variant="outline"
@@ -486,14 +465,13 @@ export function Categories() {
 
       {/* Edit Category Dialog */}
       <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-        <DialogContent className="sm:max-w-[500px]">
+        <DialogContent className="sm:max-w-[400px]">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <Edit className="w-5 h-5 text-primary" />
               Editar Categoría
             </DialogTitle>
           </DialogHeader>
-
           <div className="space-y-4 py-4">
             <div className="space-y-2">
               <Label htmlFor="edit-name">Nombre *</Label>
@@ -513,24 +491,27 @@ export function Categories() {
                 <p className="text-sm text-destructive">{formErrors.name}</p>
               )}
             </div>
-
             <div className="space-y-2">
-              <Label htmlFor="edit-description">Descripción</Label>
-              <Textarea
-                id="edit-description"
-                value={categoryFormData.description}
-                onChange={(e) =>
+              <Label>Estado</Label>
+              <Select
+                value={categoryFormData.status}
+                onValueChange={(value) =>
                   setCategoryFormData({
                     ...categoryFormData,
-                    description: e.target.value,
+                    status: value as "active" | "inactive",
                   })
                 }
-                placeholder="Descripción de la categoría (opcional)"
-                rows={3}
-              />
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="active">Activa</SelectItem>
+                  <SelectItem value="inactive">Inactiva</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </div>
-
           <div className="flex justify-end gap-3">
             <Button
               variant="outline"


### PR DESCRIPTION
## Summary
- integrate backend endpoints for product categories
- support pagination and search
- show category status
- handle add, edit and delete via API

## Testing
- `npm run typecheck` *(fails: cannot find modules in unrelated files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68859c391f34832989c58df6de74f7c2