### PR TITLE
Implement Kardex history API

### DIFF
--- a/shared/api.ts
+++ b/shared/api.ts
@@ -251,6 +251,17 @@ export interface ProductMovement {
   product?: Product;
 }
 
+// Simplified movement returned by the Kardex endpoint
+export interface KardexMovement {
+  id: string;
+  productId: string;
+  quantity: number;
+  type: "in" | "out";
+  date: string;
+  userId: string;
+  relatedDocument?: string;
+}
+
 // Package & Session Types
 export interface Package {
   id: string;
@@ -310,6 +321,22 @@ export interface SaleItem {
   productId: string;
   quantity: number;
   price: number;
+  product?: Product;
+}
+
+// Purchase Types
+export interface Purchase {
+  id: string;
+  supplierId: string;
+  userId: string;
+  date: string;
+  products: PurchaseItem[];
+}
+
+export interface PurchaseItem {
+  productId: string;
+  quantity: number;
+  unitPrice: number;
   product?: Product;
 }
 


### PR DESCRIPTION
## Summary
- map new Kardex endpoint into shared types
- fetch product list and kardex movements via `/api/kardex/product/:id`
- post purchases to `/api/purchase` when recording inventory entries

## Testing
- `npm run typecheck` *(fails: errors in Workers.tsx)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688855fed6888329a9243b7246d7abb7