### PR TITLE
feat: persist view mode and split dashboards

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -19,9 +19,10 @@ export function Layout({ children, title, subtitle }: LayoutProps) {
     const stored = localStorage.getItem("podocare_sidebar_collapsed");
     return stored ? JSON.parse(stored) : false;
   });
-  const [viewMode, setViewMode] = useState<"admin" | "worker">(
-    user?.role || "worker",
-  );
+  const [viewMode, setViewMode] = useState<"admin" | "worker">(() => {
+    const stored = localStorage.getItem("podocare_view_mode");
+    return stored ? JSON.parse(stored) : user?.role || "worker";
+  });
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -31,9 +32,16 @@ export function Layout({ children, title, subtitle }: LayoutProps) {
 
   useEffect(() => {
     if (user) {
-      setViewMode(user.role);
+      const stored = localStorage.getItem("podocare_view_mode");
+      setViewMode(
+        stored ? JSON.parse(stored) : user.role,
+      );
     }
   }, [user]);
+
+  useEffect(() => {
+    localStorage.setItem("podocare_view_mode", JSON.stringify(viewMode));
+  }, [viewMode]);
 
   const handleLogout = () => {
     logout();

--- a/client/lib/auth/context.tsx
+++ b/client/lib/auth/context.tsx
@@ -110,6 +110,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
     tokenStorage.setToken(accessToken);
     tokenStorage.setUser(mapped);
+    localStorage.setItem("podocare_view_mode", mapped.role);
     setToken(accessToken);
     setUser(mapped);
     return mapped;
@@ -117,6 +118,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const logout = () => {
     tokenStorage.clear();
+    localStorage.removeItem("podocare_view_mode");
     setToken(null);
     setUser(null);
     window.location.href = "/login";


### PR DESCRIPTION
## Summary
- persist selected view (admin/worker) in local storage so it survives navigation
- reset stored view on logout and initialize on login
- show distinct admin and worker dashboards with mock stats and activity

## Testing
- `npm test`
- `npm run typecheck` *(fails: Property 'lastName' does not exist on type 'Patient', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68958925c1a88329ad1acbdedcda17c9