### PR TITLE
feat: persist view mode and split dashboards

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -19,9 +19,17 @@ export function Layout({ children, title, subtitle }: LayoutProps) {
     const stored = localStorage.getItem("podocare_sidebar_collapsed");
     return stored ? JSON.parse(stored) : false;
   });
-  const [viewMode, setViewMode] = useState<"admin" | "worker">(
-    user?.role || "worker",
-  );
+  const [viewMode, setViewMode] = useState<"admin" | "worker">(() => {
+    const stored = localStorage.getItem("podocare_view_mode");
+    if (stored) {
+      try {
+        return JSON.parse(stored);
+      } catch {
+        return stored as "admin" | "worker";
+      }
+    }
+    return user?.role || "worker";
+  });
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -31,9 +39,22 @@ export function Layout({ children, title, subtitle }: LayoutProps) {
 
   useEffect(() => {
     if (user) {
-      setViewMode(user.role);
+      const stored = localStorage.getItem("podocare_view_mode");
+      if (stored) {
+        try {
+          setViewMode(JSON.parse(stored));
+        } catch {
+          setViewMode(stored as "admin" | "worker");
+        }
+      } else {
+        setViewMode(user.role);
+      }
     }
   }, [user]);
+
+  useEffect(() => {
+    localStorage.setItem("podocare_view_mode", viewMode);
+  }, [viewMode]);
 
   const handleLogout = () => {
     logout();

--- a/client/lib/auth/context.tsx
+++ b/client/lib/auth/context.tsx
@@ -110,6 +110,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
     tokenStorage.setToken(accessToken);
     tokenStorage.setUser(mapped);
+    localStorage.setItem("podocare_view_mode", mapped.role);
     setToken(accessToken);
     setUser(mapped);
     return mapped;
@@ -117,6 +118,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const logout = () => {
     tokenStorage.clear();
+    localStorage.removeItem("podocare_view_mode");
     setToken(null);
     setUser(null);
     window.location.href = "/login";

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useState } from "react";
 import {
   Activity,
   Users,
@@ -43,7 +42,7 @@ interface RecentActivity {
 }
 
 // Mock data - in a real app this would come from API
-const mockStats: DashboardStats = {
+const mockAdminStats: DashboardStats = {
   totalPatients: 247,
   todayAppointments: 12,
   todayIncome: 1580,
@@ -54,7 +53,18 @@ const mockStats: DashboardStats = {
   completedAppointments: 8,
 };
 
-const mockRecentActivity: RecentActivity[] = [
+const mockWorkerStats: DashboardStats = {
+  totalPatients: 32,
+  todayAppointments: 5,
+  todayIncome: 320,
+  lowStockAlerts: 0,
+  weeklyAppointments: 18,
+  monthlyIncome: 2400,
+  activeWorkers: 1,
+  completedAppointments: 3,
+};
+
+const mockAdminActivity: RecentActivity[] = [
   {
     id: "1",
     type: "appointment",
@@ -79,6 +89,28 @@ const mockRecentActivity: RecentActivity[] = [
     type: "appointment",
     description: "Cita reagendada con Ana García",
     time: "1:45 PM",
+  },
+];
+
+const mockWorkerActivity: RecentActivity[] = [
+  {
+    id: "1",
+    type: "appointment",
+    description: "Cita completada con Juan Pérez",
+    time: "09:00 AM",
+  },
+  {
+    id: "2",
+    type: "patient",
+    description: "Nuevo paciente: Luisa Fernanda",
+    time: "11:30 AM",
+  },
+  {
+    id: "3",
+    type: "payment",
+    description: "Pago recibido - Control mensual",
+    time: "12:15 PM",
+    amount: 80,
   },
 ];
 
@@ -158,50 +190,87 @@ const useAuth = () => {
 
 export function Dashboard() {
   const { user } = useAuth();
-  const navigate = useNavigate();
-  const [stats, setStats] = useState<DashboardStats>(mockStats);
-  const [recentActivity, setRecentActivity] =
-    useState<RecentActivity[]>(mockRecentActivity);
+  const storedMode = localStorage.getItem("podocare_view_mode");
+  const viewMode: "admin" | "worker" = storedMode
+    ? (() => {
+        try {
+          return JSON.parse(storedMode);
+        } catch {
+          return storedMode as "admin" | "worker";
+        }
+      })()
+    : user?.role || "worker";
+
+  const stats = viewMode === "admin" ? mockAdminStats : mockWorkerStats;
+  const recentActivity =
+    viewMode === "admin" ? mockAdminActivity : mockWorkerActivity;
 
   return (
     <Layout title="Dashboard" subtitle="Resumen de tu clínica podológica">
       <div className="p-4 lg:p-6 space-y-6">
         {/* Quick Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          <StatCard
-            title="Total Pacientes"
-            value={stats.totalPatients}
-            icon={Users}
-            trend="up"
-            trendValue="+12%"
-            color="primary"
-          />
-          <StatCard
-            title="Citas Hoy"
-            value={`${stats.completedAppointments}/${stats.todayAppointments}`}
-            icon={Calendar}
-            trend="up"
-            trendValue="+5%"
-            color="secondary"
-          />
-          <StatCard
-            title="Ingresos Hoy"
-            value={`S/ ${stats.todayIncome.toLocaleString()}`}
-            icon={DollarSign}
-            trend="up"
-            trendValue="+8%"
-            color="accent"
-          />
-          <StatCard
-            title="Stock Bajo"
-            value={stats.lowStockAlerts}
-            icon={AlertTriangle}
-            color="warning"
-          />
-        </div>
+        {viewMode === "admin" ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            <StatCard
+              title="Total Pacientes"
+              value={stats.totalPatients}
+              icon={Users}
+              trend="up"
+              trendValue="+12%"
+              color="primary"
+            />
+            <StatCard
+              title="Citas Hoy"
+              value={`${stats.completedAppointments}/${stats.todayAppointments}`}
+              icon={Calendar}
+              trend="up"
+              trendValue="+5%"
+              color="secondary"
+            />
+            <StatCard
+              title="Ingresos Hoy"
+              value={`S/ ${stats.todayIncome.toLocaleString()}`}
+              icon={DollarSign}
+              trend="up"
+              trendValue="+8%"
+              color="accent"
+            />
+            <StatCard
+              title="Stock Bajo"
+              value={stats.lowStockAlerts}
+              icon={AlertTriangle}
+              color="warning"
+            />
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <StatCard
+              title="Citas Hoy"
+              value={`${stats.completedAppointments}/${stats.todayAppointments}`}
+              icon={Calendar}
+              trend="up"
+              trendValue="+5%"
+              color="primary"
+            />
+            <StatCard
+              title="Ingresos Hoy"
+              value={`S/ ${stats.todayIncome.toLocaleString()}`}
+              icon={DollarSign}
+              trend="up"
+              trendValue="+8%"
+              color="secondary"
+            />
+            <StatCard
+              title="Pacientes Totales"
+              value={stats.totalPatients}
+              icon={Users}
+              color="accent"
+            />
+          </div>
+        )}
 
         {/* Additional Stats Row */}
-        {user.role === "admin" && (
+        {viewMode === "admin" && (
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             <StatCard
               title="Citas Semanales"
@@ -278,10 +347,7 @@ export function Dashboard() {
             </CardHeader>
             <CardContent>
               <div
-                className={cn(
-                  "grid gap-3",
-                  user?.role === "admin" ? "grid-cols-2" : "grid-cols-2",
-                )}
+                className={cn("grid gap-3", viewMode === "admin" ? "grid-cols-2" : "grid-cols-2")}
               >
                 <Button
                   onClick={() => navigate("/appointments/new")}
@@ -306,7 +372,7 @@ export function Dashboard() {
                   <ShoppingBag className="w-6 h-6" />
                   <span className="text-sm">Vender Producto</span>
                 </Button>
-                {user?.role === "admin" ? (
+                {viewMode === "admin" ? (
                   <Button
                     onClick={() => navigate("/reports")}
                     variant="outline"


### PR DESCRIPTION
## Summary
- persist selected view (admin/worker) in local storage so it survives navigation
- reset stored view on logout and initialize on login
- show distinct admin and worker dashboards with mock stats and activity
- handle legacy localStorage values for view mode to avoid JSON.parse errors

## Testing
- `npm test`
- `npm run typecheck` *(fails: Property 'lastName' does not exist on type 'Patient', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68958925c1a88329ad1acbdedcda17c9