### PR TITLE
feat: show payment stats from api

### DIFF
--- a/client/lib/auth/api.ts
+++ b/client/lib/auth/api.ts
@@ -8,10 +8,11 @@ export interface HttpResponse<T = any> {
 }
 
 // Shape returned by the backend API
-export interface ApiResponse<T> {
+export interface ApiResponse<T, S = any> {
   state: string;
   message: string;
   data: T;
+  stats?: S;
 }
 
 export class AuthenticatedFetch {

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -185,6 +185,28 @@ export interface CreatePaymentRequest {
   method: "cash" | "transfer" | "yape" | "pos" | "plin" | "balance";
 }
 
+export interface PaymentStats {
+  range: {
+    from: string;
+    to: string;
+  };
+  totals: {
+    _id: string | null;
+    amountAll: number;
+    amountCompleted: number;
+    countAll: number;
+    countCompleted: number;
+    countPending: number;
+    countFailed: number;
+  };
+  today: {
+    _id: string | null;
+    amount: number;
+    count: number;
+  };
+  byMethod: Record<string, { amount: number; count: number }>;
+}
+
 // Abonos (Partial Payments) Types
 export interface Abono {
   id: string;


### PR DESCRIPTION
## Summary
- add `PaymentStats` interface and optional stats in API response
- request payment list with `includeStats` and render returned metrics

## Testing
- `npm test`
- `npm run typecheck` *(fails: Property 'username' is missing in type ...)*

------
https://chatgpt.com/codex/tasks/task_e_689790dba7b48329b6850f783ab1fd3c