### PR TITLE
feat: set application timezone to Lima

### DIFF
--- a/client/components/appointments/AppointmentDetailStory.tsx
+++ b/client/components/appointments/AppointmentDetailStory.tsx
@@ -4,6 +4,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Calendar, User, UserCheck, CheckCircle, XCircle, Clock, DollarSign, FileText } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { formatDate, formatTime } from "@shared/time";
 
 type AnyAppt = any;
 
@@ -13,21 +14,6 @@ const getQty = (p: any) => Number(p.quantity ?? p.qty ?? 1);
 // Normaliza paciente/worker con tu API (patient || patientId / worker || userId)
 const getPatient = (a: AnyAppt) => a.patient ?? a.patientId ?? {};
 const getWorker = (a: AnyAppt) => a.worker ?? a.userId ?? {};
-
-const formatDate = (iso?: string) =>
-  iso
-    ? new Date(iso).toLocaleDateString("es-PE", {
-      weekday: "short",
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    })
-    : "—";
-
-const formatTime = (iso?: string) =>
-  iso
-    ? new Date(iso).toLocaleTimeString("es-PE", { hour: "2-digit", minute: "2-digit" })
-    : "—";
 
 const calcProductsTotal = (products: any[] = []) =>
   products.reduce((acc, p) => acc + Number(p.price || 0) * getQty(p), 0);

--- a/client/pages/Appointments.tsx
+++ b/client/pages/Appointments.tsx
@@ -48,6 +48,7 @@ import { useRepositoryPagination } from "@/hooks/use-repository-pagination";
 
 // 🔗 APIs
 import { Appointment, CreateAppointmentRequest, Patient, PatientListItem } from "@shared/api";
+import { todayISODate } from "@shared/time";
 import { AppointmentRepository } from "@/lib/api/appointment";
 import { PatientRepository } from "@/lib/api/patient";
 import { WorkerRepository } from "@/lib/api/worker";
@@ -102,7 +103,7 @@ export function Appointments() {
   const appointmentRepository = useMemo(() => new AppointmentRepository(), []);
   const patientRepository = useMemo(() => new PatientRepository(), []);
   const workerRepository = useMemo(() => new WorkerRepository(), []);
-  const today = new Date().toISOString().split("T")[0];
+  const today = todayISODate();
 
   /* =========================
    *  Filtros y estado UI

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,9 @@ import cors from "cors";
 import { handleDemo } from "./routes/demo";
 import { validateToken, refreshToken, logout } from "./routes/auth";
 import appointmentRouter from "./routes/appointment";
+import { TIME_ZONE } from "../shared/time";
+
+process.env.TZ = TIME_ZONE;
 
 export function createServer() {
   const app = express();

--- a/shared/time.ts
+++ b/shared/time.ts
@@ -1,0 +1,31 @@
+export const TIME_ZONE = 'America/Lima';
+export const LOCALE = 'es-PE';
+
+export const todayISODate = (): string => {
+  const now = new Date();
+  const lima = new Date(now.toLocaleString('en-US', { timeZone: TIME_ZONE }));
+  const year = lima.getFullYear();
+  const month = String(lima.getMonth() + 1).padStart(2, '0');
+  const day = String(lima.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export const formatDate = (iso?: string) =>
+  iso
+    ? new Date(iso).toLocaleDateString(LOCALE, {
+        weekday: 'short',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        timeZone: TIME_ZONE,
+      })
+    : '—';
+
+export const formatTime = (iso?: string) =>
+  iso
+    ? new Date(iso).toLocaleTimeString(LOCALE, {
+        hour: '2-digit',
+        minute: '2-digit',
+        timeZone: TIME_ZONE,
+      })
+    : '—';


### PR DESCRIPTION
## Summary
- add shared timezone helpers for Lima/Peru
- use Lima timezone on server startup
- leverage shared helpers for appointment display

## Testing
- `npm test`
- `npm run typecheck` *(fails: Property 'lastName' does not exist on type 'Patient')*

------
https://chatgpt.com/codex/tasks/task_e_68998b2eb26483298f1a9a45b1e7afa0