### PR TITLE
fix: include full day in date range filtering

### DIFF
--- a/client/lib/repositories/local/base.ts
+++ b/client/lib/repositories/local/base.ts
@@ -171,6 +171,10 @@ export abstract class LocalStorageBaseRepository<
     const start = new Date(startDate);
     const end = new Date(endDate);
 
+    // Normalise boundaries to include the entire days
+    start.setHours(0, 0, 0, 0);
+    end.setHours(23, 59, 59, 999);
+
     return items.filter((item) => {
       const itemDate = new Date(item[dateField] as string);
       return itemDate >= start && itemDate <= end;

--- a/client/pages/Appointments.tsx
+++ b/client/pages/Appointments.tsx
@@ -203,8 +203,11 @@ export function Appointments() {
       filters.userId = user.id;
     }
 
+    // Actualiza los filtros y fuerza a que la carga use los más recientes
     pagination.setFilters(filters);
-    await pagination.loadData((params) => appointmentRepository.getAll(params));
+    await pagination.loadData((params) =>
+      appointmentRepository.getAll({ ...params, ...filters }),
+    );
   };
 
   /* =========================


### PR DESCRIPTION
## Summary
- normalize date range boundaries to include full days when filtering

## Testing
- `npm test`
- `npm run typecheck` *(fails: Property 'lastName' does not exist on type 'Patient' ... and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899997638e48329b2298eefce2c12f5